### PR TITLE
Remove unneeded requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,24 @@
 
 Julia support for the [`lsp-mode`](https://github.com/emacs-lsp/lsp-mode) package using the [LanguageServer.jl](https://github.com/JuliaEditorSupport/LanguageServer.jl) package. For information on the features `lsp-mode` provides see their [website](https://github.com/emacs-lsp/lsp-mode).
 
-This package uses the Emacs Speaks Statistics ([ESS](https://github.com/emacs-ess/ESS)) package.
+It's recommended to use this package with the Emacs Speaks Statistics ([ESS](https://github.com/emacs-ess/ESS)) package.
 
 *A julia version >= 0.6 has to be in your path*
 
 _This package is still under development._
 
 ## Installation
+### Installing the Julia Language Server
+Open a Julia REPL and install LanguageServer.jl.
 
-First, make sure that the ESS package is installed by following the instruction presented on their [website](https://github.com/emacs-ess/ESS/wiki/Julia).
+```julia
+julia> Pkg.add("LanguageServer")
+```
 
-Then, clone this repository to a suitable path. Add the following lines to your `.emacs` file:
+### Installing `lsp-julia`
+
+Clone this repository to a suitable path. Add the following lines to your `.emacs` file:
+
 ```emacs-lisp
 (add-to-list 'load-path "<path to lsp-mode>")
 (add-to-list 'load-path "<path to lsp-julia>")
@@ -20,6 +27,13 @@ Then, clone this repository to a suitable path. Add the following lines to your 
     (require 'lsp-flycheck))
 (require 'lsp-julia)
 (require 'lsp-mode)
+```
+
+### Using `lsp-julia` with ESS
+
+First, make sure that the ESS package is installed by following the instruction presented on their [website](https://github.com/emacs-ess/ESS/wiki/Julia). Then in addition to the above, add the following to your `.emacs` file.
+
+```emacs-lisp
 (add-hook 'ess-julia-mode-hook #'lsp-mode)
 ```
 

--- a/lsp-julia.el
+++ b/lsp-julia.el
@@ -1,5 +1,3 @@
-(require 'ess-site)
-(require 'julia-mode)
 (require 'lsp-mode)
 
 (defun lsp-julia--get-root ()


### PR DESCRIPTION
Removes the `require` for `julia-mode` and `ess-site` since they aren't actually used **by** this package.