### PR TITLE
Make lsp-mode wait long enough for Julia to startup

### DIFF
--- a/lsp-julia.el
+++ b/lsp-julia.el
@@ -22,7 +22,8 @@ If no .gitignore file can be found use the default directory "
      (lambda(w _p)))))
 
 (defun lsp-julia--initialize-client(client)
-  (mapcar #'(lambda (p) (lsp-client-on-notification client (car p) (cdr p))) lsp-julia--handlers))
+  (mapcar #'(lambda (p) (lsp-client-on-notification client (car p) (cdr p))) lsp-julia--handlers)
+  (setq-local lsp-response-timeout 30))
 
 (lsp-define-stdio-client lsp-julia "julia" #'lsp-julia--get-root nil
                          :command-fn #'lsp-julia--rls-command

--- a/lsp-julia.el
+++ b/lsp-julia.el
@@ -2,6 +2,10 @@
 (require 'julia-mode)
 (require 'lsp-mode)
 
+(defcustom lsp-julia-timeout 30
+  "Time before lsp-mode should assume julia just ain't gonna start."
+  :group 'lsp-julia)
+
 (defun lsp-julia--get-root ()
   "Try to find the package directory by searching for a .gitignore file.
 If no .gitignore file can be found use the default directory "
@@ -23,7 +27,7 @@ If no .gitignore file can be found use the default directory "
 
 (defun lsp-julia--initialize-client(client)
   (mapcar #'(lambda (p) (lsp-client-on-notification client (car p) (cdr p))) lsp-julia--handlers)
-  (setq-local lsp-response-timeout 30))
+  (setq-local lsp-response-timeout lsp-julia-timeout))
 
 (lsp-define-stdio-client lsp-julia "julia" #'lsp-julia--get-root nil
                          :command-fn #'lsp-julia--rls-command


### PR DESCRIPTION
lsp-mode has a tendency to give up on LanguageServer.jl responding before Julia has even finished starting up. By raising `lsp-response-timeout` to 30 seconds, we can actually get lsp-mode talking with the language server.